### PR TITLE
Constrain allowed characters in meting, profiel and reeks.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of metfilelib
 0.16 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Constrain allowed characters in meting, profiel and reeks.
 
 
 0.15 (2014-03-06)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import sys
 import tempfile
+
 from optparse import OptionParser
 
 tmpeggs = tempfile.mkdtemp()
@@ -34,16 +35,12 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --setup-source and --download-base to point to
-local resources, you can keep this script from going over the network.
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
 parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-parser.add_option("-d", "--distribute",
-                  dest='unused_option_yeah_really',
-                  action="store_true", default=False,
-                  help="UNUSED, BBB for nens fabfile that passes -d")
 
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
@@ -55,45 +52,58 @@ parser.add_option("-t", "--accept-buildout-test-releases",
                         "bootstrap and buildout will get the newest releases "
                         "even if they are alphas or betas."))
 parser.add_option("-c", "--config-file",
-                   help=("Specify the path to the buildout configuration "
-                         "file to be used."))
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
 parser.add_option("-f", "--find-links",
-                   help=("Specify a URL to search for buildout releases"))
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--setuptools-version",
+                  help="use a specific setuptools version")
 
 
 options, args = parser.parse_args()
 
 ######################################################################
-# load/install distribute
+# load/install setuptools
 
-to_reload = False
 try:
-    import pkg_resources
-    import setuptools
-    if not hasattr(pkg_resources, '_distribute'):
-        to_reload = True
-        raise ImportError
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
 except ImportError:
-    ez = {}
+    from urllib2 import urlopen
 
-    try:
-        from urllib.request import urlopen
-    except ImportError:
-        from urllib2 import urlopen
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-    exec(urlopen('http://python-distribute.org/distribute_setup.py').read(),
-         ez)
-    setup_args = dict(to_dir=tmpeggs, download_delay=0, no_fake=True)
-    ez['use_setuptools'](**setup_args)
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
-    if to_reload:
-        reload(pkg_resources)
-    import pkg_resources
-    # This does not (always?) update the default working set.  We will
-    # do it.
-    for path in sys.path:
-        if path not in pkg_resources.working_set.entries:
-            pkg_resources.working_set.add_entry(path)
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
 
 ######################################################################
 # Install buildout
@@ -113,8 +123,8 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-distribute_path = ws.find(
-    pkg_resources.Requirement.parse('distribute')).location
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
 
 requirement = 'zc.buildout'
 version = options.version
@@ -124,12 +134,17 @@ if version is None and not options.accept_buildout_test_releases:
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
-        search_path=[distribute_path])
+        search_path=[setuptools_path])
     if find_links:
         index.add_find_links((find_links,))
     req = pkg_resources.Requirement.parse(requirement)
@@ -152,10 +167,9 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=distribute_path)) != 0:
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
     raise Exception(
-        "Failed to execute command:\n%s",
-        repr(cmd)[1:-1])
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 
 ######################################################################
 # Import and run buildout

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -23,8 +23,8 @@ eggs =
 [versions]
 # Specific pins
 metfilelib =
-zc.buildout = 2.0.0
-zc.recipe.egg = 2.0.0a3
+zc.buildout = 2.4.0
+zc.recipe.egg = 2.0.2
 
 # Reported by buildout.
 

--- a/metfilelib/parser.py
+++ b/metfilelib/parser.py
@@ -45,8 +45,8 @@ def parse_version(file_object):
                 version = "?"
         else:
             file_object.record_error(
-          "Versie regel moet beginnen met <VERSIE> en eindigen met </VERSIE>",
-          "MET_NOVERSION")
+                "Versie regel moet beginnen met <VERSIE> en eindigen met </VERSIE>",
+                "MET_NOVERSION")
             version = "?"
         file_object.next()
         return version
@@ -75,8 +75,8 @@ def parse_series(file_object):
     else:
         if not l.startswith("<REEKS>") or not l.endswith("</REEKS>"):
             file_object.record_error(
-          "Reeks regel moet beginnen met <REEKS> en eindigen met </REEKS>",
-          "MET_NOREEKS")
+                "Reeks regel moet beginnen met <REEKS> en eindigen met </REEKS>",
+                "MET_NOREEKS")
         else:
             seriesre = re.compile("<REEKS>(.*),(.*),</REEKS>")
             match = seriesre.match(l)
@@ -86,8 +86,8 @@ def parse_series(file_object):
                 series_name = match.group(2)
             else:
                 file_object.record_error(
-              "Reeks regel moet 2 door komma's gevolgde elementen bevatten",
-              "MET_REEKSELEMENTS")
+                    "Reeks regel moet 2 door komma's gevolgde elementen bevatten",
+                    "MET_REEKSELEMENTS")
 
                 # Try to continue parsing without the second comma
                 seriesre = re.compile("<REEKS>(.*),(.*)</REEKS>")
@@ -108,8 +108,8 @@ def parse_series(file_object):
             "MET_NOPROFILES")
 
     return metfile.Series(
-            line_number=line_number, id=series_id,
-            name=series_name, profiles=tuple(profiles))
+        line_number=line_number, id=series_id,
+        name=series_name, profiles=tuple(profiles))
 
 
 def parse_profile(file_object):
@@ -170,7 +170,7 @@ def parse_profile(file_object):
     date_measurement = parse_date(match.group(3))
     if date_measurement is None:
         file_object.record_error(
-      "Ongeldige datum, niet in JJJJMMDD formaat: {0}".format(match.group(3)),
+            "Ongeldige datum, niet in JJJJMMDD formaat: {0}".format(match.group(3)),
             "MET_WRONGDATE")
 
     file_object.next()
@@ -233,8 +233,8 @@ def parse_meting(file_object):
 
     if len(groups) != 6:
         file_object.record_error(
-     "Een <METING> regel moet 6 met komma's gescheiden elementen bevatten",
-     "MET_METINGSIXVALUES")
+            "Een <METING> regel moet 6 met komma's gescheiden elementen bevatten",
+            "MET_METINGSIXVALUES")
         file_object.next()
         return
 
@@ -274,13 +274,13 @@ def parse_meting(file_object):
     profile_drawing_code = groups[1]
 
     if (profile_point_type
-        not in metfile.Measurement.ALLOWED_PROFILE_POINT_TYPES):
+            not in metfile.Measurement.ALLOWED_PROFILE_POINT_TYPES):
         file_object.record_error(
             "Onbekende profielpunttype {0}".format(profile_point_type),
             "MET_UNKNOWN_PROFILE_POINT_TYPE")
 
     if (profile_drawing_code
-        not in metfile.Measurement.ALLOWED_DRAWING_CODES):
+            not in metfile.Measurement.ALLOWED_DRAWING_CODES):
         file_object.record_error(
             "Onbekende profieltekencode {0}".format(profile_drawing_code),
             "MET_UNKNOWN_PROFILE_DRAWING_CODE")
@@ -305,7 +305,7 @@ def parse_date(date_string):
 
     try:
         return datetime.date(int(date_string[:4]),
-                         int(date_string[4:6]),
-                         int(date_string[6:8]))
+                             int(date_string[4:6]),
+                             int(date_string[6:8]))
     except ValueError:
         return None

--- a/metfilelib/parser.py
+++ b/metfilelib/parser.py
@@ -78,7 +78,7 @@ def parse_series(file_object):
                 "Reeks regel moet beginnen met <REEKS> en eindigen met </REEKS>",
                 "MET_NOREEKS")
         else:
-            seriesre = re.compile("<REEKS>(.*),(.*),</REEKS>")
+            seriesre = re.compile("<REEKS>([\w.-]*),([\w.-]*),</REEKS>")
             match = seriesre.match(l)
 
             if match:
@@ -90,8 +90,9 @@ def parse_series(file_object):
                     "MET_REEKSELEMENTS")
 
                 # Try to continue parsing without the second comma
-                seriesre = re.compile("<REEKS>(.*),(.*)</REEKS>")
+                seriesre = re.compile("<REEKS>([\w.-]*),([\w.-]*)</REEKS>")
                 match = seriesre.match(l)
+
         file_object.next()
 
     profiles = []
@@ -121,7 +122,7 @@ def parse_profile(file_object):
             "Profiel regel moet beginnen met <PROFIEL>",
             "MET_NOPROFIEL")
 
-    profilere = re.compile("<PROFIEL>" + 10 * "([^,]*),")
+    profilere = re.compile("<PROFIEL>" + 10 * "([\w.-]*),")
     match = profilere.match(l)
 
     if not match:
@@ -220,10 +221,17 @@ def parse_meting(file_object):
         file_object.next()
         return
 
-    metingre = re.compile("<METING>(.*)</METING>")
+    metingre = re.compile("<METING>([\d.,-]*)</METING>")
     match = metingre.match(l)
 
-    groups = match.group(1).split(",")
+    try:
+        groups = match.group(1).split(",")
+    except AttributeError:
+        file_object.record_error(
+            "Een <METING> object bevat invalide tekens.",
+            "MET_METINGSIXVALUES")
+        file_object.next()
+        return
 
     if len(groups) == 7 and not groups[6]:
         # There are 7, but the last one is empty (extra comma):

--- a/metfilelib/parser.py
+++ b/metfilelib/parser.py
@@ -78,7 +78,7 @@ def parse_series(file_object):
                 "Reeks regel moet beginnen met <REEKS> en eindigen met </REEKS>",
                 "MET_NOREEKS")
         else:
-            seriesre = re.compile("<REEKS>([\w.-]*),([\w.-]*),</REEKS>")
+            seriesre = re.compile("<REEKS>([^<>,]*),([^<>,]*),</REEKS>")
             match = seriesre.match(l)
 
             if match:
@@ -90,7 +90,7 @@ def parse_series(file_object):
                     "MET_REEKSELEMENTS")
 
                 # Try to continue parsing without the second comma
-                seriesre = re.compile("<REEKS>([\w.-]*),([\w.-]*)</REEKS>")
+                seriesre = re.compile("<REEKS>([^<>,]*),([^<>,]*)</REEKS>")
                 match = seriesre.match(l)
 
         file_object.next()
@@ -122,7 +122,7 @@ def parse_profile(file_object):
             "Profiel regel moet beginnen met <PROFIEL>",
             "MET_NOPROFIEL")
 
-    profilere = re.compile("<PROFIEL>" + 10 * "([\w.-]*),")
+    profilere = re.compile("<PROFIEL>" + 10 * "([^<>,]*),")
     match = profilere.match(l)
 
     if not match:
@@ -221,7 +221,7 @@ def parse_meting(file_object):
         file_object.next()
         return
 
-    metingre = re.compile("<METING>([\d.,-]*)</METING>")
+    metingre = re.compile("<METING>([\d\s.,-]*)</METING>")
     match = metingre.match(l)
 
     try:

--- a/metfilelib/scripts/switch_z1z2.py
+++ b/metfilelib/scripts/switch_z1z2.py
@@ -46,7 +46,7 @@ class LineReplacer(object):
         return self.lines[line_to_yield]
 
     def replace(self, l):
-        print('line {num} becomes {l}'.format(num=self.last_yielded_line, l=l)
+        print('line {num} becomes {l}'.format(num=self.last_yielded_line, l=l))
         if self.lines[self.last_yielded_line] != l:
             self.lines[self.last_yielded_line] = l
             self.changed = True
@@ -67,7 +67,7 @@ def switched(line):
 
 def switch_z1z2():
     for path in files():
-        print("Processing '{path}'.".format(path=path)
+        print("Processing '{path}'.".format(path=path))
         with LineReplacer(path) as replacer:
             for line in replacer:
                 replacer.replace(switched(line))

--- a/metfilelib/scripts/switch_z1z2.py
+++ b/metfilelib/scripts/switch_z1z2.py
@@ -17,7 +17,7 @@ def files():
     d = directory()
     for filename in os.listdir(d):
         if (os.path.splitext(filename)[-1].lower() in
-            ('.txt', '.met')):
+           ('.txt', '.met')):
             yield os.path.join(d, filename)
 
 
@@ -29,7 +29,7 @@ class LineReplacer(object):
         self.path = path
 
     def __enter__(self):
-        self.lines = open(path, 'rU').readlines()
+        self.lines = open(self.path, 'rU').readlines()
         self.last_yielded_line = None
         self.changed = False
 

--- a/metfilelib/tests/test_metfile.py
+++ b/metfilelib/tests/test_metfile.py
@@ -36,3 +36,23 @@ class TestProfile(TestCase):
         self.assertEquals(len(sorted_measurements), 7)
         self.assertEquals(sorted_measurements[0].profile_point_type, '1')
         self.assertEquals(sorted_measurements[-1].profile_point_type, '2')
+
+    def test_invalid_characters_in_meting(self):
+        reader = get_mock_reader([
+            b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NAP,ABS,2,XY,112372.752,485955.504,\n",
+            b"<METING>2,999,15.0,15.0,-5.241,-5.241</METING>\n",
+            b"<METING>1,999,-5.0,-5.0,-4.255,-4.255</METING>\n",
+            b"<METING>22,999,0.0,00,-5.824,-5.824</METING>\n",
+            b"<METING>22,999,10.0,10.0,-5.824,-5.824</METING>\n",
+            b"<METING>5,999,2.0,2.>0,-5.874,-5.844</METING>\n",
+            b"<METING>5,999,4.0,4.0,-6.044,-5.984</METING>\n",
+            b"<METING>5,999,7.0,7.0,-6.084,-6.02</METING>\n",
+            b"</PROFIEL>\n"
+        ])
+
+        profile = parser.parse_profile(reader)
+
+        sorted_measurements = profile.sorted_measurements
+        self.assertEquals(len(sorted_measurements), 6)
+        self.assertEquals(sorted_measurements[0].profile_point_type, '1')
+        self.assertEquals(sorted_measurements[-1].profile_point_type, '2')

--- a/metfilelib/tests/test_metfile.py
+++ b/metfilelib/tests/test_metfile.py
@@ -12,7 +12,6 @@ from __future__ import division
 from unittest import TestCase
 
 from metfilelib import parser
-from metfilelib import metfile
 
 from metfilelib.tests.test_parser import get_mock_reader
 
@@ -20,16 +19,16 @@ from metfilelib.tests.test_parser import get_mock_reader
 class TestProfile(TestCase):
     def test_this_example_appears_to_loop_forever(self):
         reader = get_mock_reader([
-                b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NAP,ABS,2,XY,112372.752,485955.504,\n",
-                b"<METING>2,999,15.0,15.0,-5.241,-5.241</METING>\n",
-                b"<METING>1,999,-5.0,-5.0,-4.255,-4.255</METING>\n",
-                b"<METING>22,999,0.0,0.0,-5.824,-5.824</METING>\n",
-                b"<METING>22,999,10.0,10.0,-5.824,-5.824</METING>\n",
-                b"<METING>5,999,2.0,2.0,-5.874,-5.844</METING>\n",
-                b"<METING>5,999,4.0,4.0,-6.044,-5.984</METING>\n",
-                b"<METING>5,999,7.0,7.0,-6.084,-6.02</METING>\n",
-                b"</PROFIEL>\n"
-                ])
+            b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NAP,ABS,2,XY,112372.752,485955.504,\n",
+            b"<METING>2,999,15.0,15.0,-5.241,-5.241</METING>\n",
+            b"<METING>1,999,-5.0,-5.0,-4.255,-4.255</METING>\n",
+            b"<METING>22,999,0.0,0.0,-5.824,-5.824</METING>\n",
+            b"<METING>22,999,10.0,10.0,-5.824,-5.824</METING>\n",
+            b"<METING>5,999,2.0,2.0,-5.874,-5.844</METING>\n",
+            b"<METING>5,999,4.0,4.0,-6.044,-5.984</METING>\n",
+            b"<METING>5,999,7.0,7.0,-6.084,-6.02</METING>\n",
+            b"</PROFIEL>\n"
+        ])
 
         profile = parser.parse_profile(reader)
 

--- a/metfilelib/tests/test_parser.py
+++ b/metfilelib/tests/test_parser.py
@@ -17,8 +17,8 @@ from metfilelib import parser
 
 def get_mock_reader(lines):
     with mock.patch(
-        '__builtin__.open',
-        return_value=mock_file_factory(lines)):
+            '__builtin__.open',
+            return_value=mock_file_factory(lines)):
         reader = file_reader.FileReader("/some/filename")
     return reader
 
@@ -26,24 +26,24 @@ def get_mock_reader(lines):
 class TestVersion(TestCase):
     def test_success_with_correct_line(self):
         reader = get_mock_reader([
-                b"<VERSIE>1.0</VERSIE>\n"
-            ])
+            b"<VERSIE>1.0</VERSIE>\n"
+        ])
 
         parser.parse_version(reader)
         self.assertTrue(reader.success)
 
     def test_error_if_version_not_10(self):
         reader = get_mock_reader([
-                b"<VERSIE>2.0</VERSIE>\n"
-            ])
+            b"<VERSIE>2.0</VERSIE>\n"
+        ])
 
         parser.parse_version(reader)
         self.assertFalse(reader.success)
 
     def test_if_version_line_missing_doesnt_move_line_number(self):
         reader = get_mock_reader([
-                b"<REEKS>testing,testing,</REEKS>\n"
-            ])
+            b"<REEKS>testing,testing,</REEKS>\n"
+        ])
 
         parser.parse_version(reader)
         self.assertFalse(reader.success)
@@ -53,24 +53,24 @@ class TestVersion(TestCase):
 class TestParseSeries(TestCase):
     def test_success_with_correct_line(self):
         reader = get_mock_reader([
-                b"<REEKS>deeleen,deeltwee,</REEKS>\n",
-                b"<PROFIEL>O-BR00001927_516,PROFIEL_516,20120421,0.00,NAP,ABS,2,XY,152168.401,444100.055,\n",
-b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n",
-b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
-                b"</PROFIEL>\n"
-                ])
+            b"<REEKS>deeleen,deeltwee,</REEKS>\n",
+            b"<PROFIEL>O-BR00001927_516,PROFIEL_516,20120421,0.00,NAP,ABS,2,XY,152168.401,444100.055,\n",
+            b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n",
+            b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
+            b"</PROFIEL>\n"
+        ])
 
         print(reader.errors)
         self.assertTrue(reader.success)
 
     def test_error_with_a_result_when_second_comma_missing(self):
         reader = get_mock_reader([
-                b"<REEKS>deeleen,deeltwee</REEKS>\n",
-                b"<PROFIEL>O-BR00001927_516,PROFIEL_516,20120421,0.00,NAP,ABS,2,XY,152168.401,444100.055,\n",
-b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n",
-b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
-                b"</PROFIEL>\n"
-                ])
+            b"<REEKS>deeleen,deeltwee</REEKS>\n",
+            b"<PROFIEL>O-BR00001927_516,PROFIEL_516,20120421,0.00,NAP,ABS,2,XY,152168.401,444100.055,\n",
+            b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n",
+            b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
+            b"</PROFIEL>\n"
+        ])
 
         result = parser.parse_series(reader)
         self.assertFalse(reader.success)
@@ -80,16 +80,16 @@ b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
 class TestParseProfiel(TestCase):
     def test_this_example_appears_to_loop_forever(self):
         reader = get_mock_reader([
-                b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NAP,ABS,2,XY,112372.752,485955.504,\n",
-                b"METING>1,999,112372.752,485955.504,-4.255,-4.255</METING>\n",
-                b"<METING>22,999,112373.939,485957.095,-5.824,-5.824</METING>\n",
-                b"<METING>5,999,112373.945,485957.103,-5.874,-5.844</METING>\n",
-                b"<METING>5,999,112374.248,485957.488,-6.044,-5.984</METING>\n",
-                b"<METING>5,999,112374.557,485957.881,-6.154,-6.084</METING>\n",
-                b"<METING>22,999,112378.091,485962.366,-5.824,-5.824</METING>\n",
-                b"<METING>2,999,112378.509,485962.92,-5.241,-5.241</METING>\n",
-                b"</PROFIEL>\n"
-                ])
+            b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NAP,ABS,2,XY,112372.752,485955.504,\n",
+            b"METING>1,999,112372.752,485955.504,-4.255,-4.255</METING>\n",
+            b"<METING>22,999,112373.939,485957.095,-5.824,-5.824</METING>\n",
+            b"<METING>5,999,112373.945,485957.103,-5.874,-5.844</METING>\n",
+            b"<METING>5,999,112374.248,485957.488,-6.044,-5.984</METING>\n",
+            b"<METING>5,999,112374.557,485957.881,-6.154,-6.084</METING>\n",
+            b"<METING>22,999,112378.091,485962.366,-5.824,-5.824</METING>\n",
+            b"<METING>2,999,112378.509,485962.92,-5.241,-5.241</METING>\n",
+            b"</PROFIEL>\n"
+        ])
         parser.parse_profile(reader)
         self.assertEquals(reader.line_number, 10)
 
@@ -98,7 +98,7 @@ class TestParseMeting(TestCase):
     def test_numbers_converted_to_float(self):
         reader = get_mock_reader([
             b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n"
-            ])
+        ])
 
         meting = parser.parse_meting(reader)
 
@@ -112,7 +112,7 @@ class TestParseMeting(TestCase):
     def test_x_is_not_a_valid_float(self):
         reader = get_mock_reader([
             b"<METING>22,999,152.168.401,444100.055,2.206,2.206</METING>\n"
-            ])
+        ])
 
         parser.parse_meting(reader)
 
@@ -123,7 +123,7 @@ class TestParseMeting(TestCase):
         not result in an error."""
         reader = get_mock_reader([
             b"<METING>22,,152168.401,444100.055,2.206,2.206</METING>\n"
-            ])
+        ])
 
         parser.parse_meting(reader)
 

--- a/metfilelib/tests/test_parser.py
+++ b/metfilelib/tests/test_parser.py
@@ -63,6 +63,19 @@ class TestParseSeries(TestCase):
         print(reader.errors)
         self.assertTrue(reader.success)
 
+    def test_invalid_characters_in_reeks(self):
+        reader = get_mock_reader([
+            b"<REEKS>deeleen,deeltw<ee,</REEKS>\n",
+            b"<PROFIEL>O-BR00001927_516,PROFIEL_516,20120421,0.00,NAP,ABS,2,XY,152168.401,444100.055,\n",
+            b"<METING>22,999,152168.401,444100.055,2.206,2.206</METING>\n",
+            b"<METING>99,999,152168.475,444100.136,1.556,1.661</METING>\n",
+            b"</PROFIEL>\n"
+        ])
+
+        result = parser.parse_series(reader)
+        self.assertFalse(reader.success)
+        self.assertNotEqual(result, None)
+
     def test_error_with_a_result_when_second_comma_missing(self):
         reader = get_mock_reader([
             b"<REEKS>deeleen,deeltwee</REEKS>\n",
@@ -92,6 +105,22 @@ class TestParseProfiel(TestCase):
         ])
         parser.parse_profile(reader)
         self.assertEquals(reader.line_number, 10)
+
+    def test_invalid_characters_in_profiel(self):
+        reader = get_mock_reader([
+            b"<PROFIEL>W81-2_1,Profiel_1,20130114,0,NA>P,ABS,2,XY,112372.752,485955.504,\n",
+            b"<METING>2,999,15.0,15.0,-5.241,-5.241</METING>\n",
+            b"<METING>1,999,-5.0,-5.0,-4.255,-4.255</METING>\n",
+            b"<METING>22,999,0.0,00,-5.824,-5.824</METING>\n",
+            b"<METING>22,999,10.0,10.0,-5.824,-5.824</METING>\n",
+            b"<METING>5,999,2.0,2.>0,-5.874,-5.844</METING>\n",
+            b"<METING>5,999,4.0,4.0,-6.044,-5.984</METING>\n",
+            b"<METING>5,999,7.0,7.0,-6.084,-6.02</METING>\n",
+            b"</PROFIEL>\n"
+        ])
+
+        parser.parse_profile(reader)
+        self.assertFalse(reader.success)
 
 
 class TestParseMeting(TestCase):
@@ -123,6 +152,15 @@ class TestParseMeting(TestCase):
         not result in an error."""
         reader = get_mock_reader([
             b"<METING>22,,152168.401,444100.055,2.206,2.206</METING>\n"
+        ])
+
+        parser.parse_meting(reader)
+
+        self.assertFalse(reader.success)
+
+    def test_invalid_character(self):
+        reader = get_mock_reader([
+            b"<METING>22,999,152.401,444100.>055,2.206,2.206</METING>\n"
         ])
 
         parser.parse_meting(reader)


### PR DESCRIPTION
Constrain the allowed characters between:

* ``<METING>`` and ``</METING>``: only numeric, ``.``, space and ``-``
* ``<REEKS>`` and ``</REEKS>``: everything but ``<``, ``>``
* ``<PROFIEL>`` and ``<METING>``: everything but ``<``, ``>``